### PR TITLE
Passing the entity id as a parameter to the getValidationRules method

### DIFF
--- a/src/Controllers/CrudController.php
+++ b/src/Controllers/CrudController.php
@@ -162,7 +162,7 @@ abstract class CrudController extends RootController
 			return $hookResult;
 		}
 
-		$validator = Validator::make($data, $this->model->getValidationRules());
+		$validator = Validator::make($data, $this->model->getValidationRules($entity->id));
 
 		if ($validator->fails()) {
 			return $this->response->build(

--- a/src/Models/CrudModelInterface.php
+++ b/src/Models/CrudModelInterface.php
@@ -11,8 +11,10 @@ interface CrudModelInterface
 	 * The returned value is an array of rules as
 	 * explained in the official Laravel documentation.
 	 *
+	 * @param integer $entityId The id of the instance of the model being
+	 * processed.
 	 * @return array
 	 * @link https://laravel.com/docs/5.2/validation
 	 */
-	public function getValidationRules();
+	public function getValidationRules($entityId = null);
 }


### PR DESCRIPTION
This little modification on the getValidationRules of the Crud controller would enable the possibility of passing the id of the updating entities to their `unique` validation rules so they can be updated. The issue is described in #19 .
